### PR TITLE
Check lpass version

### DIFF
--- a/config_properties.py
+++ b/config_properties.py
@@ -1,1 +1,2 @@
-version=0.6
+version = 0.6
+lpass = "1.0.0"

--- a/main.py
+++ b/main.py
@@ -24,8 +24,9 @@ wf = Workflow()
 
 
 class VersionMismatch(Exception):
-    def __init__(self, lpass_version, required_min_version):
-        Exception.__init__(self, "Found LastPass CLI Version {0}, Min Required Version {1}".format(lpass_version, required_min_version))
+    def __init__(self, installed_lpass_version, required_min_version):
+        Exception.__init__(self, "Found LastPass CLI Version {0}, Min Required Version {1}".format(
+            installed_lpass_version, required_min_version))
 
 
 def main(wf):
@@ -92,12 +93,12 @@ def main(wf):
 
 def precheck():
     try:
-        actual_lpass_version = subprocess.check_output('/usr/local/bin/lpass --version', shell=True)
+        installed_lpass_version = subprocess.check_output('/usr/local/bin/lpass --version', shell=True)
         required_min_version = config_properties.lpass
-        lpass_version = re.search(r'([\d.]*\d+)', actual_lpass_version)
-        lpass_version = lpass_version.group()
-        if StrictVersion(lpass_version) < StrictVersion(required_min_version):
-            raise VersionMismatch(lpass_version, required_min_version)
+        installed_lpass_version = re.search(r'([\d.]*\d+)', installed_lpass_version)
+        installed_lpass_version = installed_lpass_version.group()
+        if StrictVersion(installed_lpass_version) < StrictVersion(required_min_version):
+            raise VersionMismatch(installed_lpass_version, required_min_version)
     except CalledProcessError:
         wf.add_item(title='Unable to read output from lpass --version',
                         subtitle="You probably need to upgrade your last pass cli",

--- a/main.py
+++ b/main.py
@@ -1,20 +1,31 @@
 from __future__ import unicode_literals
+from collections import defaultdict
+from distutils.version import StrictVersion
+import json
+import os
+import re
 import subprocess
+from subprocess import CalledProcessError
+import sys
+import urllib
+
+import requests
+
+import config_properties
 import hostnameSearch
 import usernameSearch
-import os
-from collections import defaultdict
-import config_properties
-import urllib
-import requests
-import json
-import sys
 from workflow.workflow import Workflow
+
 
 vaultHostMap = defaultdict(list)
 vaultUsernameMap = defaultdict(list)
 UPDATE_INTERVAL = 3600 * 3
 wf = Workflow()
+
+
+class VersionMismatch(Exception):
+    def __init__(self, lpass_version, required_min_version):
+        Exception.__init__(self, "Found LastPass CLI Version {0}, Min Required Version {1}".format(lpass_version, required_min_version))
 
 
 def main(wf):
@@ -81,8 +92,23 @@ def main(wf):
 
 def precheck():
     try:
+        actual_lpass_version = subprocess.check_output('/usr/local/bin/lpass --version', shell=True)
+        required_min_version = config_properties.lpass
+        lpass_version = re.search(r'([\d.]*\d+)', actual_lpass_version)
+        lpass_version = lpass_version.group()
+        if StrictVersion(lpass_version) < StrictVersion(required_min_version):
+            raise VersionMismatch(lpass_version, required_min_version)
+    except CalledProcessError:
+        wf.add_item(title='Unable to read output from lpass --version',
+                        subtitle="You probably need to upgrade your last pass cli",
+                        icon='icon.png',
+                        valid=True)
+        send_feedback()
+        sys.exit(0)
+
+    try:
         subprocess.check_output('/usr/local/bin/lpass status', shell=True)
-    except Exception as e:
+    except CalledProcessError:
         wf.add_item(title='You are not logged into lpass-cli',
                     subtitle="Please login through the terminal to continue",
                     icon='icon.png',


### PR DESCRIPTION
Added logic to check the version of the last pass cli installed and make sure its greater than the min version now listed in the config_properties.py.  If the we cant read the output from the lpass --version command we catch the proper exception.  If we find a version mismatch we raise a custom exception.
